### PR TITLE
cpp - xyt representation - implement unitwait

### DIFF
--- a/instances/singleagent-icaps2020/den520d/den520d.xml
+++ b/instances/singleagent-icaps2020/den520d/den520d.xml
@@ -274,6 +274,8 @@
         <decisionalgorithm>miniminbackup</decisionalgorithm>
         <learningalgorithm>dijkstralearning</learningalgorithm>
         <maxnumofintervalspermove>10</maxnumofintervalspermove>
+        <isunitwaitrepresentation>true</isunitwaitrepresentation>
+        <unitwaitduration>1</unitwaitduration>
 	</algorithm>
 	<options>
 		<loglevel>1</loglevel>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -12,6 +12,7 @@ Config::Config()
     planforturns = CN_DEFAULT_PLANFORTURNS;
     additionalwait = CN_DEFAULT_ADDITIONALWAIT;
     fixedlookahead = CNS_DEFAULT_FIXEDLOOKAHEADLIMIT;
+    additionalwait = CNS_DEFAULT_UNITWAITDURATION;
 }
 
 bool Config::getConfig(const char* fileName)
@@ -367,6 +368,46 @@ bool Config::getConfig(const char* fileName)
         stream>>maxNumOfIntervalsPerMove;
         stream.clear();
         stream.str("");
+    }
+
+    element = algorithm->FirstChildElement(CNS_TAG_UNITWAITDURATION);
+    if (!element)
+    {
+        std::cout << "Warning! No '"<<CNS_TAG_UNITWAITDURATION<<"' element found inside '"<<CNS_TAG_ALGORITHM<<"' section. Its value is set to '"<<CNS_DEFAULT_UNITWAITDURATION<<"'."<<std::endl;
+        unitWaitDuration = CNS_DEFAULT_UNITWAITDURATION;
+    }
+    else
+    {
+        value = element->GetText();
+        stream<<value;
+        stream>>unitWaitDuration;
+        stream.clear();
+        stream.str("");
+        if(unitWaitDuration < 0 || unitWaitDuration > 100)
+        {
+            std::cout << "Warning! Wrong value of '"<<CNS_TAG_UNITWAITDURATION<<"' element. It should belong to the interval [0,100]. Its value is set to '"<<CNS_DEFAULT_UNITWAITDURATION<<"'."<<std::endl;
+            unitWaitDuration = CNS_DEFAULT_UNITWAITDURATION;
+        }
+    }
+
+    element = algorithm->FirstChildElement(CNS_TAG_IS_UNITWAITREPRESENTATION);
+    if (!element)
+    {
+        std::cout << "Error! No '"<<CNS_TAG_IS_UNITWAITREPRESENTATION<<"' element found inside '"<<CNS_TAG_ALGORITHM<<"' section. Its value is set '"<<CNS_DEFAULT_IS_UNITWAITREPRESENTATION<<"'."<<std::endl;
+        isUnitWaitRepresentation = CNS_DEFAULT_IS_UNITWAITREPRESENTATION;
+    }
+    else
+    {
+        value = element->GetText();
+        if(value == "true" || value == "1")
+            isUnitWaitRepresentation = true;
+        else if(value == "false" || value == "0")
+            isUnitWaitRepresentation = false;
+        else
+        {
+            std::cout << "Warning! Wrong '"<<CNS_TAG_IS_UNITWAITREPRESENTATION<<"' value. It's set to '"<<CNS_DEFAULT_IS_UNITWAITREPRESENTATION<<"'."<<std::endl;
+            isUnitWaitRepresentation = CNS_DEFAULT_IS_UNITWAITREPRESENTATION;
+        }
     }
     return true;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -37,6 +37,8 @@ public:
     std::string decisionalgorithm;
     int dynmode;
     unsigned long maxNumOfIntervalsPerMove;
+    double unitWaitDuration;
+    bool isUnitWaitRepresentation;
     bool getConfig(const char* fileName);
 };
 

--- a/src/gl_const.h
+++ b/src/gl_const.h
@@ -39,6 +39,8 @@
 #define CNS_DEFAULT_EXPANSIONALGORITHM      "astar"
 #define CNS_DEFAULT_DYNMODE                     0
 #define CNS_DEFAULT_MAXNUMOFINTEVALS        CN_INFINITY
+#define CNS_DEFAULT_UNITWAITDURATION        1
+#define CNS_DEFAULT_IS_UNITWAITREPRESENTATION "false"
 
 
 #define CN_HEADING_WHATEVER                 -1
@@ -127,6 +129,8 @@
     #define CNS_TAG_DECISIONALGORITHM       "decisionalgorithm"
     #define CNS_TAG_DYNMODE                 "dynmode"
     #define CNS_TAG_MAXNUMOFINTEVALS        "maxnumofintervalspermove"
+    #define CNS_TAG_UNITWAITDURATION        "unitwaitduration"
+    #define CNS_TAG_IS_UNITWAITREPRESENTATION "isunitwaitrepresentation"
 
 /*
  * End of XML files tags -------------------------------------------------------

--- a/src/situatedSIPP/realtime_sipp.cpp
+++ b/src/situatedSIPP/realtime_sipp.cpp
@@ -487,6 +487,10 @@ double Realtime_SIPP::calcHeading(const RTNode& node, const RTNode& son)
 std::list<RTNode> Realtime_SIPP::findSuccessors(const RTNode curNode,
                                                 const Map&   map)
 {
+    /*if (config->isUnitWaitRepresentation){*/
+        //return findSuccessorsUsingUnitWaitRepresentation(curNode, map);
+    /*}*/
+
     RTNode                    newNode;
     RTNode                    angleNode;
     std::list<RTNode>         successors;
@@ -540,47 +544,80 @@ std::list<RTNode> Realtime_SIPP::findSuccessors(const RTNode curNode,
                 }
             }
             if (config->allowanyangle) {
-                newNode = resetParent(newNode, curNode, map);
-                if (newNode.Parent->i != parent->i ||
-                    newNode.Parent->j != parent->j) {
-                    angleNode       = *newNode.Parent;
-                    newNode.heading = calcHeading(
-                      *newNode.Parent,
-                      newNode); // new heading with respect to new parent
-                    angleNode.set_static_g(
-                      angleNode.g() +
-                      getRCost(angleNode.heading, newNode.heading) +
-                      config->additionalwait); // count new additional time
-                                               // required for rotation
-                    newNode.set_static_g(
-                      newNode.g() +
-                      getRCost(angleNode.heading, newNode.heading) +
-                      config->additionalwait);
-                    newNode.Parent = &angleNode;
-                    if (angleNode.g() > angleNode.interval.end) {
-                        continue;
-                    }
-                    intervals =
-                      constraints->findIntervals(newNode, EAT, close, map);
-                    unsigned long num_of_intervals = std::min(config->maxNumOfIntervalsPerMove, intervals.size());
-                    for (unsigned int k = 0; k < num_of_intervals; k++) {
-                        newNode.interval = intervals[k];
-                        newNode.Parent   = parent->Parent;
-                        newNode.set_static_g(newNode.Parent->g() +
-                                             getCost(newNode.Parent->i,
-                                                     newNode.Parent->j,
-                                                     newNode.i, newNode.j));
-                        newNode.set_dynamic_g(EAT[k] - newNode.static_g());
-                        newNode.interval_id = newNode.interval.id;
-                        successors.push_front(newNode);
-                    }
-                }
+                std::cerr << "Please disable allowanyangle in cofig\n";
+                exit(1);
             }
         }
     }
 
     return successors;
 }
+
+/*std::list<RTNode> Realtime_SIPP::findSuccessorsUsingUnitWaitRepresentation(const RTNode curNode,*/
+        //const Map&   map)
+//{
+    //RTNode                    newNode;
+    //RTNode                    angleNode;
+    //std::list<RTNode>         successors;
+    //std::vector<double>       EAT;
+    //std::vector<SafeInterval> intervals;
+    //// double                    h_value;
+    //auto parent = &(close.find(curNode.i * map.width + curNode.j)->second);
+    //std::vector<RTNode> moves = map.getValidRTMoves(
+      //curNode.i, curNode.j, config->connectedness, curagent.size);
+    //for (auto m : moves) {
+        //if (lineofsight.checkTraversability(curNode.i + m.i, curNode.j + m.j,
+                                            //map)) {
+            //newNode.i          = curNode.i + m.i;
+            //newNode.j          = curNode.j + m.j;
+            //newNode.heading_id = m.heading_id;
+            //constraints->updateCellSafeIntervals({newNode.i, newNode.j});
+            //newNode.heading = calcHeading(curNode, newNode);
+            //DEBUG_MSG_RED("MOVE");
+            //angleNode = curNode; // the same state, but with extended g-value
+            //angleNode.debug();
+            //m.debug();
+
+            //angleNode.set_static_g(
+              //angleNode.static_g() +
+              //getRCost(angleNode.heading, newNode.heading) +
+              //config->additionalwait);
+            //angleNode.debug();
+            //newNode.set_static_g(angleNode.static_g() +
+                                 //m.g() / curagent.mspeed);
+            //newNode.set_dynamic_g(angleNode.dynamic_g());
+            //newNode.Parent  = &angleNode;
+            //newNode.optimal = curNode.optimal;
+            //newNode.set_static_h(config->h_weight *
+                                 //getHValue(newNode.i, newNode.j));
+            //newNode.debug();
+            //if (angleNode.g() <= angleNode.interval.end) {
+                //intervals =
+                  //constraints->findIntervals(newNode, EAT, close, map);
+                //unsigned long num_of_intervals = std::min(config->maxNumOfIntervalsPerMove, intervals.size());
+                //for (unsigned int k = 0; k < num_of_intervals; k++) {
+                    //newNode.interval = intervals[k];
+                    //newNode.Parent   = parent;
+                    //newNode.set_static_g(newNode.Parent->static_g() +
+                                         //getCost(newNode.Parent->i,
+                                                 //newNode.Parent->j, newNode.i,
+                                                 //newNode.j) /
+                                           //curagent.mspeed);
+                    //newNode.set_dynamic_g(EAT[k] - newNode.static_g());
+                    //newNode.interval_id = newNode.interval.id;
+                    //successors.push_front(newNode);
+                //}
+            //}
+            //if (config->allowanyangle) {
+                //std::cerr << "Please disable allowanyangle in cofig\n";
+                //exit(1);
+            //}
+        //}
+    //}
+
+    //return successors;
+/*}*/
+
 
 void Realtime_SIPP::makePrimaryPath(RTNode curNode)
 {

--- a/src/situatedSIPP/realtime_sipp.h
+++ b/src/situatedSIPP/realtime_sipp.h
@@ -26,6 +26,7 @@ public:
                             const timeval& begin, const timeval& end);
 
     std::list<RTNode> findSuccessors(const RTNode curNode, const Map& map);
+    std::list<RTNode> findSuccessorsUsingUnitWaitRepresentation(const RTNode curNode, const Map& map);
     virtual void      makePrimaryPath(RTNode curNode);
     virtual void      makeSecondaryPath(RTNode curNode);
     void   calculateLineSegment(std::vector<RTNode>& line, const RTNode& start,


### PR DESCRIPTION
## What is implemented in this pull request:
xyt representation  with unitwait

## How do we implement
We edit the findSuccessor function to enable a new successor generator. The new generator generates the valid moves and valid unitwait-and-moves. For example if we have 4 movements up, down, left, right, then we will generate 8 successor at most (U,D,L,R, and unitwait-and-U, unitwait-and-D, unitwait-and-L, unitwait-and-R). The duration of unitwait can be set with parameter. 

## Two paramter added to trigger XYT-unitwait representation:

1) isunitwaitrepresentation - boolean to indicate if use unitwait representation
2) unitwaitduration - float value, we can first try 1 and 0.1

See the current den520d.xml as an example. 